### PR TITLE
Fix symbol (syntax) used for cardinality of 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ country
 # possible cardinalities:
 #
 # Cardinality    Syntax
-# 0 or 1         0
+# 0 or 1         ?
 # exactly 1      1
 # 0 or more      *
 # 1 or more      +
@@ -139,7 +139,7 @@ And here's another example that can be read as, "every platinum album has one
 or more artists, but not every artist has a platinum album":
 
 ```
-Artist +--0 PlatinumAlbums
+Artist +--? PlatinumAlbums
 ```
 
 ### Fonts, colors, labels, ...


### PR DESCRIPTION
When using '0' as described in the README so far,
the following error is reported:

  unexpected "0"
  expecting relationship

(using erd installed from cabal today).

I tried '?', by consistency, which worked,
and checked the source code, which reads:

  let ops = "?1*+"

leaving no doubt.
