### PR TITLE
Stack build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .*.swp
+*~
 dist
 bin
 tags
+.stack-work

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ and build from source:
 
     git clone git://github.com/BurntSushi/erd
     cd erd
-    stack init
     stack install
 
 `stack install` will put the binary into Stack's standard binary

--- a/README.md
+++ b/README.md
@@ -16,9 +16,28 @@ directory](https://github.com/BurntSushi/erd/blob/master/examples/nfldb.er).
 
 ### Installation
 
-`erd` requires [Haskell](http://www.haskell.org/platform/) and
-[GraphViz](http://www.graphviz.org/Download..php). Both are available for 
-Windows, Mac and Linux.
+`erd` requires [GraphViz](http://www.graphviz.org/Download..php), and one of:
+
+* [Stack](http://docs.haskellstack.org/en/stable/README/)
+* [Haskell Platform](http://www.haskell.org/platform/)
+
+All of these are available for Windows, Mac and Linux.
+
+#### Stack
+
+Install the [Stack](http://docs.haskellstack.org/en/stable/README/) build tool,
+and build from source:
+
+    git clone git://github.com/BurntSushi/erd
+    cd erd
+    stack init
+    stack install
+
+`stack install` will put the binary into Stack's standard binary
+installation path.  Unless you've overriden it, that's `~/.local/bin`
+on Unix and OS X, `%APPDATA%\local\bin` on Windows.
+
+#### Haskell Platform
 
 [erd is on hackage](http://hackage.haskell.org/package/erd), so you can install 
 it with cabal (which is included with the Haskell platform):

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,10 @@
+resolver: lts-5.8
+
+packages:
+- '.'
+
+extra-deps: []
+
+flags: {}
+
+extra-package-dbs: []


### PR DESCRIPTION
`erd` built trivially under Stack, just by running these two commands:

```
stack init
stack install
```

This pull request therefore has no big changes, it just bundles a default `stack.yaml` and updates the `README.md` to reflect the option to build with Stack.  I made the choice to put the Stack instructions ahead of Cabal; my reasoning is that Stack is inherently less prone to dependency hell and thus should be the preferred option.
