### PR TITLE
Easy Haskell install

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ brew reinstall graphviz --with-pango
 [erd is on hackage](http://hackage.haskell.org/package/erd), so you can install 
 it with cabal (which is included with the Haskell platform):
 
-    cabal install erd
+    cabal install --allow-newer erd
 
 Alternatively, you can clone this repository and build from source:
 


### PR DESCRIPTION
I spent 3 hours trying to install this package. As a first time Haskell user, I tried everything with no clue what I was doing until I saw this comment: https://github.com/BurntSushi/erd/issues/24#issuecomment-314775206 by @chreble.

I installed Haskell just to use this library for RDB ERD's. I don't want to learn Haskell or understand how this works*.  I think there are others like me who would benefit from this simple fix in the documentation.

I don't know if this is a bug in my Haskell install, the Haskell language / cabal or the dependencies in the ERD package, but as a first time Haskell user, I just wanted this package to work. 

*Actually, I'm always curious how things work, but when I step into a whole new domain, I'd rather see it work before learning the details. :)