### PR TITLE
Create a PR template that default to WIP tag

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ labels: WIP
 
 issue : #
 
-assign to : @
+reviewers : @
 
 
 Please mention @ zhujinxuan when your PR is finished, then he will remove the WIP label.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,8 +7,10 @@ labels: WIP
 
 ## This PR provides or resolves
 - 
+-
 
 ## This PR is related to:
 
 issue : #
+
 assign to : @

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+---
+labels: WIP
+---
+
+## Is it a bug fix, a feature or refaction?
+
+
+## This PR provides or resolves
+- 
+
+## This PR is related to:
+
+issue : #
+assign to : @

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,6 @@ labels: WIP
 issue : #
 
 assign to : @
+
+
+Please mention @ zhujinxuan when your PR is finished, then he will remove the WIP label.


### PR DESCRIPTION
## Is it a bug fix, a feature or refaction?

Refactor

## This PR provides or resolves
- Makes all PR default with WIP label

## This PR is related to:

issue: https://github.com/BurntSushi/erd/issues/42#issuecomment-464765720

@BurntSushi , how do you think of this template?  If it is good, then I will squash and merge this PR.