### PR TITLE
Very rough support of regular dot tables as output

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The PDF should now contain a graph that looks like this:
 | -o FILE  | --output=FILE   | When set, output will be written to the given file. Otherwise, stdout will be used. If given and if --fmt is omitted, then the format will be guessed from the file extension. |
 | -f FMT   | --fmt=FMT       | Force the output format to one of: bmp, dot, eps, gif, jpg, pdf, plain, png, ps, ps2, svg, tiff.                                                                               |
 | -e EDGE  | --edge=EDGE     | Select one type of edge: compound, noedge, ortho, poly, spline.                                                                                                                |
+| -d       | --dot-entity    | When set, output will consist of regular dot tables instead of HTML tables. Formatting will be disabled.                                                                       |
 | -h       | --help          | Show this usage message.                                                                                                                                                       |
 
 ### Formatting defined in configuration file
@@ -415,10 +416,6 @@ You can output a `dot` file using the `--fmt` option or by simply using it as
 a file extension:
 
     erd -i something.er -o something.dot
-
-Note though that `erd` writes entities as HTML tables, so the resulting `dot`
-may not be so useful. (I would not be against a small addition to `erd` that
-uses no formatting and writes entities as regular dot tables.)
 
 
 ### Similar software

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -34,19 +34,12 @@ main = do
     Left err -> do
       hPutStrLn stderr err
       exitFailure
-    Right er -> let erDot = (chooseGenerator conf) conf er
+    Right er -> let erDot = dotER conf er
                     toFile h = SB.hGetContents h >>= SB.hPut (snd $ cout conf)
                     fmt = fromMaybe Pdf (outfmt conf)
                  in graphvizWithHandle Dot erDot fmt toFile
   hClose (snd $ cin conf)
   hClose (snd $ cout conf)
-
--- | Chooses a GraphViz generator from a hardcoded predicate.
-chooseGenerator :: Config -> (Config -> ER -> G.DotGraph L.Text)
-chooseGenerator conf = if nohtml conf then
-                            dotERNoHtml
-                        else
-                            dotER
 
 -- | Converts an entire ER-diagram from an ER file into a GraphViz graph.
 dotER :: Config -> ER -> G.DotGraph L.Text
@@ -55,40 +48,26 @@ dotER conf er = graph' $ do
   graphAttrs [ A.RankDir A.FromLeft
              , A.Splines $ fromMaybe (fromJust . edgeType $ defaultConfig) (edgeType conf)
              ]
-  nodeAttrs [shape PlainText] -- recommended for HTML labels
+  nodeAttrs nodeGlobalAttributes  
   edgeAttrs [ A.Color [A.toWC $ A.toColor C.Gray50] -- easier to read labels
             , A.MinLen 2 -- give some breathing room
             , A.Style [A.SItem A.Dashed []] -- easier to read labels, maybe?
             ]
   forM_ (entities er) $ \e ->
-    node (name e) [toLabel (htmlEntity e)]
+    node (name e) [entityFmt e]
   forM_ (rels er) $ \r -> do
     let optss    = roptions r
         rlab     = A.HtmlLabel . H.Text . htmlFont optss . L.pack . show
         (l1, l2) = (A.TailLabel $ rlab $ card1 r, A.HeadLabel $ rlab $ card2 r)
         label    = A.Label $ A.HtmlLabel $ H.Text $ withLabelFmt " %s " optss []
     edge (entity1 r) (entity2 r) [label, l1, l2]
+    where nodeGlobalAttributes 
+            | dotentity conf = [shape Record, A.RankDir A.FromTop]
+            | otherwise = [shape PlainText] -- recommended for HTML labels
+          entityFmt 
+            | dotentity conf = toLabel . dotEntity
+            | otherwise = toLabel . htmlEntity
 
--- | Converts an entire ER-diagram from an ER file into a GraphViz graph.
-dotERNoHtml:: Config -> ER -> G.DotGraph L.Text
-dotERNoHtml conf er = graph' $ do
-  graphAttrs (graphTitle $ title er)
-  graphAttrs [ A.RankDir A.FromLeft
-             , A.Splines $ fromMaybe (fromJust . edgeType $ defaultConfig) (edgeType conf)
-             ]
-  nodeAttrs [shape Record, A.RankDir $ A.FromTop]  
-  edgeAttrs [ A.Color [A.toWC $ A.toColor C.Gray50] -- easier to read labels
-            , A.MinLen 2 -- give some breathing room
-            , A.Style [A.SItem A.Dashed []] -- easier to read labels, maybe?
-            ]
-  forM_ (entities er) $ \e ->
-    node (name e) [toLabel (dotEntity e)]
-  forM_ (rels er) $ \r -> do
-    let optss    = roptions r
-        rlab     = A.HtmlLabel . H.Text . htmlFont optss . L.pack . show
-        (l1, l2) = (A.TailLabel $ rlab $ card1 r, A.HeadLabel $ rlab $ card2 r)
-        label    = A.Label $ A.HtmlLabel $ H.Text $ withLabelFmt " %s " optss []
-    edge (entity1 r) (entity2 r) [label, l1, l2]
 
 -- | Converts a single entity to an HTML label.
 htmlEntity :: Entity -> H.Label

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -48,7 +48,7 @@ dotER conf er = graph' $ do
   graphAttrs [ A.RankDir A.FromLeft
              , A.Splines $ fromMaybe (fromJust . edgeType $ defaultConfig) (edgeType conf)
              ]
-  nodeAttrs nodeGlobalAttributes  
+  nodeAttrs nodeGlobalAttributes
   edgeAttrs [ A.Color [A.toWC $ A.toColor C.Gray50] -- easier to read labels
             , A.MinLen 2 -- give some breathing room
             , A.Style [A.SItem A.Dashed []] -- easier to read labels, maybe?
@@ -61,13 +61,12 @@ dotER conf er = graph' $ do
         (l1, l2) = (A.TailLabel $ rlab $ card1 r, A.HeadLabel $ rlab $ card2 r)
         label    = A.Label $ A.HtmlLabel $ H.Text $ withLabelFmt " %s " optss []
     edge (entity1 r) (entity2 r) [label, l1, l2]
-    where nodeGlobalAttributes 
+    where nodeGlobalAttributes
             | dotentity conf = [shape Record, A.RankDir A.FromTop]
             | otherwise = [shape PlainText] -- recommended for HTML labels
-          entityFmt 
+          entityFmt
             | dotentity conf = toLabel . dotEntity
             | otherwise = toLabel . htmlEntity
-
 
 -- | Converts a single entity to an HTML label.
 htmlEntity :: Entity -> H.Label

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -84,7 +84,7 @@ htmlEntity e = H.Table H.HTable
 
 -- | Converts a single entity to a plain Dot Label
 dotEntity :: Entity -> A.RecordFields
-dotEntity e = ( A.FieldLabel $ name e ) : map recordAttr (attribs e)
+dotEntity e =  A.FieldLabel ( name e ) : map recordAttr (attribs e)
 
 -- | Extracts and formats a graph title from the options given.
 -- The options should be title options from an ER value.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -22,7 +22,7 @@ import           Data.GraphViz.Types.Monadic
 import           Erd.Config
 import           Erd.ER
 import           Erd.Parse
-import           Erd.Render                          (htmlAttr, htmlFont,
+import           Erd.Render                          (htmlAttr, htmlFont,recordAttr,
                                                       withLabelFmt)
 
 main :: IO ()
@@ -34,12 +34,19 @@ main = do
     Left err -> do
       hPutStrLn stderr err
       exitFailure
-    Right er -> let erDot = dotER conf er
+    Right er -> let erDot = (chooseGenerator conf) conf er
                     toFile h = SB.hGetContents h >>= SB.hPut (snd $ cout conf)
                     fmt = fromMaybe Pdf (outfmt conf)
                  in graphvizWithHandle Dot erDot fmt toFile
   hClose (snd $ cin conf)
   hClose (snd $ cout conf)
+
+-- | Chooses a GraphViz generator from a hardcoded predicate.
+chooseGenerator :: Config -> (Config -> ER -> G.DotGraph L.Text)
+chooseGenerator conf = if nohtml conf then
+                            dotERNoHtml
+                        else
+                            dotER
 
 -- | Converts an entire ER-diagram from an ER file into a GraphViz graph.
 dotER :: Config -> ER -> G.DotGraph L.Text
@@ -62,6 +69,27 @@ dotER conf er = graph' $ do
         label    = A.Label $ A.HtmlLabel $ H.Text $ withLabelFmt " %s " optss []
     edge (entity1 r) (entity2 r) [label, l1, l2]
 
+-- | Converts an entire ER-diagram from an ER file into a GraphViz graph.
+dotERNoHtml:: Config -> ER -> G.DotGraph L.Text
+dotERNoHtml conf er = graph' $ do
+  graphAttrs (graphTitle $ title er)
+  graphAttrs [ A.RankDir A.FromLeft
+             , A.Splines $ fromMaybe (fromJust . edgeType $ defaultConfig) (edgeType conf)
+             ]
+  nodeAttrs [shape Record, A.RankDir $ A.FromTop]  
+  edgeAttrs [ A.Color [A.toWC $ A.toColor C.Gray50] -- easier to read labels
+            , A.MinLen 2 -- give some breathing room
+            , A.Style [A.SItem A.Dashed []] -- easier to read labels, maybe?
+            ]
+  forM_ (entities er) $ \e ->
+    node (name e) [toLabel (dotEntity e)]
+  forM_ (rels er) $ \r -> do
+    let optss    = roptions r
+        rlab     = A.HtmlLabel . H.Text . htmlFont optss . L.pack . show
+        (l1, l2) = (A.TailLabel $ rlab $ card1 r, A.HeadLabel $ rlab $ card2 r)
+        label    = A.Label $ A.HtmlLabel $ H.Text $ withLabelFmt " %s " optss []
+    edge (entity1 r) (entity2 r) [label, l1, l2]
+
 -- | Converts a single entity to an HTML label.
 htmlEntity :: Entity -> H.Label
 htmlEntity e = H.Table H.HTable
@@ -74,6 +102,10 @@ htmlEntity e = H.Table H.HTable
         text = withLabelFmt " [%s]" (hoptions e) $ boldFont hname
         hname = htmlFont (hoptions e) (name e)
         boldFont s = [H.Format H.Bold s]
+
+-- | Converts a single entity to a plain Dot Label
+dotEntity :: Entity -> A.RecordFields
+dotEntity e = ( A.FieldLabel $ name e ) : map recordAttr (attribs e)
 
 -- | Extracts and formats a graph title from the options given.
 -- The options should be title options from an ER value.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+* Support of regular dot-tables to visualize entities. (PR #74)
+
 * Text alignment in a Cell of a Table is explicitly defined. (PR #64)
 
 * New build target using _static-haskell-nix_ to create statically linked erd. (PR #61)

--- a/src/Erd/Config.hs
+++ b/src/Erd/Config.hs
@@ -40,7 +40,7 @@ data Config =
          , outfmt     :: Maybe G.GraphvizOutput
          , edgeType   :: Maybe A.EdgeType
          , configFile :: Maybe FilePath
-         , nohtml :: Bool
+         , dotentity  :: Bool
          }
 
 -- | Represents fields that are stored in the configuration file.
@@ -63,7 +63,7 @@ defaultConfig =
          , outfmt = Nothing
          , edgeType = Just A.SplineEdges
          , configFile = Nothing
-         , nohtml = False
+         , dotentity = False
          }
 
 defaultConfigFile :: B.ByteString
@@ -169,10 +169,10 @@ opts =
                 "EDGE")
       (printf "Select one type of edge:\n%s"
               (intercalate ", " $ M.keys edges))
-  , O.Option [] ["no-html"]
+  , O.Option [] ["dot-entity"]
       (O.NoArg (\cIO -> do 
                     c <- cIO
-                    return $ c { nohtml = True } ))
+                    return $ c { dotentity = True } ))
       ("When set, output will consist of regular dot tables instead of HTML tables.\n"
       ++ "Formatting will be disabled. Use only for further manual configuration.")
     

--- a/src/Erd/Config.hs
+++ b/src/Erd/Config.hs
@@ -40,6 +40,7 @@ data Config =
          , outfmt     :: Maybe G.GraphvizOutput
          , edgeType   :: Maybe A.EdgeType
          , configFile :: Maybe FilePath
+         , nohtml :: Bool
          }
 
 -- | Represents fields that are stored in the configuration file.
@@ -62,6 +63,7 @@ defaultConfig =
          , outfmt = Nothing
          , edgeType = Just A.SplineEdges
          , configFile = Nothing
+         , nohtml = False
          }
 
 defaultConfigFile :: B.ByteString
@@ -167,6 +169,14 @@ opts =
                 "EDGE")
       (printf "Select one type of edge:\n%s"
               (intercalate ", " $ M.keys edges))
+  , O.Option [] ["no-html"]
+      (O.NoArg (\cIO -> do 
+                    c <- cIO
+                    return $ c { nohtml = True } ))
+      ("When set, output will consist of regular dot tables instead of HTML tables.\n"
+      ++ "Formatting will be disabled. Use only for further manual configuration.")
+    
+
   ]
 
 -- | Reads and parses configuration file at default location: ~/.erd.yaml

--- a/src/Erd/Config.hs
+++ b/src/Erd/Config.hs
@@ -170,13 +170,11 @@ opts =
       (printf "Select one type of edge:\n%s"
               (intercalate ", " $ M.keys edges))
   , O.Option [] ["dot-entity"]
-      (O.NoArg (\cIO -> do 
+      (O.NoArg (\cIO -> do
                     c <- cIO
                     return $ c { dotentity = True } ))
       ("When set, output will consist of regular dot tables instead of HTML tables.\n"
       ++ "Formatting will be disabled. Use only for further manual configuration.")
-    
-
   ]
 
 -- | Reads and parses configuration file at default location: ~/.erd.yaml

--- a/src/Erd/Config.hs
+++ b/src/Erd/Config.hs
@@ -169,7 +169,7 @@ opts =
                 "EDGE")
       (printf "Select one type of edge:\n%s"
               (intercalate ", " $ M.keys edges))
-  , O.Option [] ["dot-entity"]
+  , O.Option "d" ["dot-entity"]
       (O.NoArg (\cIO -> do
                     c <- cIO
                     return $ c { dotentity = True } ))

--- a/src/Erd/Render.hs
+++ b/src/Erd/Render.hs
@@ -3,12 +3,14 @@
 module Erd.Render
   (htmlAttr,
    htmlFont,
+   recordAttr,
    withLabelFmt
   ) where
 
 import qualified Erd.ER                        as ER
 
 import qualified Data.GraphViz.Attributes.HTML as H
+import qualified Data.GraphViz.Attributes.Complete as A
 import qualified Data.Text.Lazy                as L
 import           Text.Printf                   (printf)
 
@@ -21,7 +23,9 @@ htmlAttr a = H.Cells [cell]
         fkfmt s = if ER.fk a then [H.Format H.Italics s] else s
         opts    = ER.aoptions a
         cellAttrs = ER.optionsTo ER.optToHtml opts
-
+-- | Converts a single attribute to a RecordField ( an element of a dot table )
+recordAttr :: ER.Attribute -> A.RecordField
+recordAttr a = A.FieldLabel $ ER.field a -- should change to add port support!
 -- | Formats an arbitrary string with the options given (using only font
 -- attributes).
 htmlFont :: ER.Options -> L.Text -> H.Text


### PR DESCRIPTION
Add a new format option: output entities as dot tables instead of html.