### PR TITLE
correct the information about the docker usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ All of these are available for Windows, Mac and Linux.
 
 An example command to use _erd_ in a _docker_ container, once this repository is successfully cloned.
 ```
-erdtag="0.2.1.0"; cd erd && docker build -t erd:$erdtag . && docker run -it erd:$erdtag "erd -h"
+erdtag="0.2.1.0"; cd erd && docker build -t erd:$erdtag . && docker run -it erd:$erdtag "--help"
 ```
 Where:
 - you shall specify your _erdtag_, that will help identifying the docker image to be created;
-- instead of using `erd -h` invoke _erd_ the way you need to.
+- instead of using `--help` invoke _erd_ the way you need to i.e.:
+  ```
+  docker run -i erd:$erdtag "--dot-entity" < examples/nfldb.er > out.pdf
+  ```
 
 #### Stack
 


### PR DESCRIPTION
When running the docker container as given in the readme
```
erdtag="0.2.1.0"; cd erd && docker build -t erd:$erdtag . && docker run -it erd:$erdtag "erd -h"
```

The following error occurs as the container only seems to expect the arguments for erd and not the full command there:


```
chris@pioneer shared_projects/erd (master %) » sudo docker run -i erd:latest "erd -h"
[sudo] password for chris:
erd does not have any positional arguments. <--

Usage: erd [flags]
  -c[FILE]  --config[=FILE]  Configuration file.
  -i FILE   --input=FILE     When set, input will be read from the given file.
                             Otherwise, stdin will be used.
  -o FILE   --output=FILE    When set, output will be written to the given file.
                             Otherwise, stdout will be used.
                             If given and if --fmt is omitted, then the format will be
                             guessed from the file extension.
  -h        --help           Show this usage message.
  -f FMT    --fmt=FMT        Force the output format to one of:
                             bmp, dot, eps, gif, jpg, pdf, plain, png, ps, ps2, svg, tiff
  -e EDGE   --edge=EDGE      Select one type of edge:
                             compound, noedge, ortho, poly, spline
  -d        --dot-entity     When set, output will consist of regular dot tables instead of HTML tables.
                             Formatting will be disabled. Use only for further manual configuration.
  -v        --version        Shows version of application and revision code..

```