### PR TITLE
docs: info for osx docker oom

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,19 @@
+# NB OSX users: You may encounter docker "memory error" like
+#
+# ````
+# The build process was killed (i.e. SIGKILL). The typical reason for this is
+# that there is not enough memory available (e.g. the OS killed a process using
+# lots of memory).
+# ```
+#
+# In this case you'll want to give docker more memory than the default (2Gb) in
+# order to build `erd`.
+#
+# To give docker more memory you can:
+#  - Find docker in your Menu Bar
+#  - Go to Preferences > Resources > Memory
+#  - and give docker more memory (eg: 4gb)
+
 FROM haskell:8
 
 WORKDIR /opt/erd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # NB OSX users: You may encounter docker "memory error" like
 #
-# ````
+# ```
 # The build process was killed (i.e. SIGKILL). The typical reason for this is
 # that there is not enough memory available (e.g. the OS killed a process using
 # lots of memory).

--- a/README.md
+++ b/README.md
@@ -39,17 +39,6 @@ Where:
   docker run -i erd:$erdtag "--dot-entity" < examples/nfldb.er > out.pdf
   ```
 
-> NB OSX users: You may encounter docker "memory error" like
-> 
-> `The build process was killed (i.e. SIGKILL). The typical reason for this is that there is not enough memory available (e.g. the OS killed a process using lots of memory).`
->
-> In this case you'll want to give docker more memory than the default (2Gb) in order to build `erd`.
->
-> To give docker more memory you can:
->  - Find docker in your Menu Bar
->  - Go to Preferences > Resources > Memory
->  - and give docker more memory (eg: 4gb)
-
 #### Stack
 
 Install the [Stack](http://docs.haskellstack.org/en/stable/README/) build tool,

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ Where:
   docker run -i erd:$erdtag "--dot-entity" < examples/nfldb.er > out.pdf
   ```
 
+> NB OSX users: You may encounter docker "memory error" like
+> 
+> `The build process was killed (i.e. SIGKILL). The typical reason for this is that there is not enough memory available (e.g. the OS killed a process using lots of memory).`
+>
+> In this case you'll want to give docker more memory than the default (2Gb) in order to build `erd`.
+>
+> To give docker more memory you can:
+>  - Find docker in your Menu Bar
+>  - Go to Preferences > Resources > Memory
+>  - and give docker more memory (eg: 4gb)
+
 #### Stack
 
 Install the [Stack](http://docs.haskellstack.org/en/stable/README/) build tool,


### PR DESCRIPTION
By default Docker for OSX only gives docker 2 Gb of memory. This may be
an issue when building the executable via docker seeing as the `aeson` library
requires a hefty amount of memory, eg:
https://github.com/haskell/aeson/issues/738

So this adds some info to the docs to help guide users on how to give docker more memory on osx