### PR TITLE
customizable edge pattern #93.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,15 +137,16 @@ The PDF should now contain a graph that looks like this:
 
 ### Available command-line options
 
-| Short    | Long            | Description                                                                                                                                                                    |
-|----------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| -c[FILE] | --config[=FILE] | Configuration file.                                                                                                                                                            |
-| -i FILE  | --input=FILE    | When set, input will be read from the given file. Otherwise, stdin will be used.                                                                                               |
-| -o FILE  | --output=FILE   | When set, output will be written to the given file. Otherwise, stdout will be used. If given and if --fmt is omitted, then the format will be guessed from the file extension. |
-| -f FMT   | --fmt=FMT       | Force the output format to one of: bmp, dot, eps, gif, jpg, pdf, plain, png, ps, ps2, svg, tiff.                                                                               |
-| -e EDGE  | --edge=EDGE     | Select one type of edge: compound, noedge, ortho, poly, spline.                                                                                                                |
-| -d       | --dot-entity    | When set, output will consist of regular dot tables instead of HTML tables. Formatting will be disabled.                                                                       |
-| -h       | --help          | Show this usage message.                                                                                                                                                       |
+| Short      | Long                   | Description                                                                                                                                                                    |
+|------------|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -c[FILE]   | --config[=FILE]        | Configuration file.                                                                                                                                                            |
+| -i FILE    | --input=FILE           | When set, input will be read from the given file. Otherwise, stdin will be used.                                                                                               |
+| -o FILE    | --output=FILE          | When set, output will be written to the given file. Otherwise, stdout will be used. If given and if --fmt is omitted, then the format will be guessed from the file extension. |
+| -f FMT     | --fmt=FMT              | Force the output format to one of: bmp, dot, eps, gif, jpg, pdf, plain, png, ps, ps2, svg, tiff.                                                                               |
+| -e EDGE    | --edge=EDGE            | Select one type of edge: compound, noedge, ortho, poly, spline.                                                                                                                |
+| -d         | --dot-entity           | When set, output will consist of regular dot tables instead of HTML tables. Formatting will be disabled.                                                                       |
+| -p PATTERN | --edge-pattern=PATTERN | Select one of the edge patterns: dashed, dotted, solid.                                                                                                                  |
+| -h         | --help                 | Show this usage message.                                                                                                                                                       |
 
 ### Formatting defined in configuration file
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -43,11 +43,7 @@ main = do
 
 -- | Converts an entire ER-diagram from an ER file into a GraphViz graph.
 dotER :: Config -> ER -> G.DotGraph L.Text
-dotER conf er =
-  let
-    unsafeFromConfigOrDefault :: (Config -> Maybe a) -> a
-    unsafeFromConfigOrDefault opt = fromJust $ opt conf <|> opt defaultConfig
-  in graph' $ do
+dotER conf er = graph' $ do
   graphAttrs (graphTitle $ title er)
   graphAttrs [ A.RankDir A.FromLeft
              , A.Splines $ unsafeFromConfigOrDefault edgeType
@@ -65,12 +61,15 @@ dotER conf er =
         (l1, l2) = (A.TailLabel $ rlab $ card1 r, A.HeadLabel $ rlab $ card2 r)
         label    = A.Label $ A.HtmlLabel $ H.Text $ withLabelFmt " %s " optss []
     edge (entity1 r) (entity2 r) [label, l1, l2]
-    where nodeGlobalAttributes
-            | dotentity conf = [shape Record, A.RankDir A.FromTop]
-            | otherwise = [shape PlainText] -- recommended for HTML labels
-          entityFmt
-            | dotentity conf = toLabel . dotEntity
-            | otherwise = toLabel . htmlEntity
+    where
+      unsafeFromConfigOrDefault :: (Config -> Maybe a) -> a
+      unsafeFromConfigOrDefault opt = fromJust $ opt conf <|> opt defaultConfig
+      nodeGlobalAttributes
+        | unsafeFromConfigOrDefault dotentity = [shape Record, A.RankDir A.FromTop]
+        | otherwise = [shape PlainText] -- recommended for HTML labels
+      entityFmt
+        | unsafeFromConfigOrDefault dotentity = toLabel . dotEntity
+        | otherwise = toLabel . htmlEntity
 
 -- | Converts a single entity to an HTML label.
 htmlEntity :: Entity -> H.Label

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -46,12 +46,12 @@ dotER :: Config -> ER -> G.DotGraph L.Text
 dotER conf er = graph' $ do
   graphAttrs (graphTitle $ title er)
   graphAttrs [ A.RankDir A.FromLeft
-             , A.Splines $ unsafeFromConfigOrDefault edgeType
+             , A.Splines $ fromConfigOrDefault edgeType
              ]
   nodeAttrs nodeGlobalAttributes
   edgeAttrs [ A.Color [A.toWC $ A.toColor C.Gray50] -- easier to read labels
             , A.MinLen 2 -- give some breathing room
-            , A.Style [A.SItem (unsafeFromConfigOrDefault edgePattern) [] ]
+            , A.Style [A.SItem (fromConfigOrDefault edgePattern) [] ]
             ]
   forM_ (entities er) $ \e ->
     node (name e) [entityFmt e]
@@ -62,13 +62,13 @@ dotER conf er = graph' $ do
         label    = A.Label $ A.HtmlLabel $ H.Text $ withLabelFmt " %s " optss []
     edge (entity1 r) (entity2 r) [label, l1, l2]
     where
-      unsafeFromConfigOrDefault :: (Config -> Maybe a) -> a
-      unsafeFromConfigOrDefault opt = fromJust $ opt conf <|> opt defaultConfig
+      fromConfigOrDefault :: (Config -> Maybe a) -> a
+      fromConfigOrDefault opt = fromJust $ opt conf <|> opt defaultConfig
       nodeGlobalAttributes
-        | unsafeFromConfigOrDefault dotentity = [shape Record, A.RankDir A.FromTop]
+        | fromConfigOrDefault dotentity = [shape Record, A.RankDir A.FromTop]
         | otherwise = [shape PlainText] -- recommended for HTML labels
       entityFmt
-        | unsafeFromConfigOrDefault dotentity = toLabel . dotEntity
+        | fromConfigOrDefault dotentity = toLabel . dotEntity
         | otherwise = toLabel . htmlEntity
 
 -- | Converts a single entity to an HTML label.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -43,15 +43,19 @@ main = do
 
 -- | Converts an entire ER-diagram from an ER file into a GraphViz graph.
 dotER :: Config -> ER -> G.DotGraph L.Text
-dotER conf er = graph' $ do
+dotER conf er =
+  let
+    unsafeFromConfigOrDefault :: (Config -> Maybe a) -> a
+    unsafeFromConfigOrDefault opt = fromJust $ opt conf <|> opt defaultConfig
+  in graph' $ do
   graphAttrs (graphTitle $ title er)
   graphAttrs [ A.RankDir A.FromLeft
-             , A.Splines $ fromMaybe (fromJust . edgeType $ defaultConfig) (edgeType conf)
+             , A.Splines $ unsafeFromConfigOrDefault edgeType
              ]
   nodeAttrs nodeGlobalAttributes
   edgeAttrs [ A.Color [A.toWC $ A.toColor C.Gray50] -- easier to read labels
             , A.MinLen 2 -- give some breathing room
-            , A.Style [A.SItem A.Dashed []] -- easier to read labels, maybe?
+            , A.Style [A.SItem (unsafeFromConfigOrDefault edgePattern) [] ]
             ]
   forM_ (entities er) $ \e ->
     node (name e) [entityFmt e]

--- a/src/Erd/Config.hs
+++ b/src/Erd/Config.hs
@@ -39,19 +39,21 @@ import           Text.RawString.QQ
 
 -- | Config represents all information from command line flags.
 data Config = Config
-    { cin        :: (String, Handle)
-    , cout       :: (String, Handle)
-    , outfmt     :: Maybe G.GraphvizOutput
-    , edgeType   :: Maybe A.EdgeType
-    , configFile :: Maybe FilePath
-    , dotentity  :: Bool
+    { cin         :: (String, Handle)
+    , cout        :: (String, Handle)
+    , outfmt      :: Maybe G.GraphvizOutput
+    , edgeType    :: Maybe A.EdgeType
+    , configFile  :: Maybe FilePath
+    , dotentity   :: Bool
+    , edgePattern :: Maybe A.StyleName
     }
 
 -- | Represents fields that are stored in the configuration file.
 data ConfigFile = ConfigFile
-    { cFmtOut    :: String
-    , cEdgeType  :: String
-    , cDotEntity :: Bool
+    { cFmtOut      :: String
+    , cEdgeType    :: String
+    , cDotEntity   :: Bool
+    , cEdgePattern :: String
     }
     deriving Show
 
@@ -60,7 +62,8 @@ instance FromJSON ConfigFile where
     ConfigFile <$>
     v .: "output-format" <*>
     v .: "edge-style" <*>
-    v .: "dot-entity"
+    v .: "dot-entity" <*>
+    v .: "edge-pattern"
   parseJSON _ = fail "Incorrect configuration file."
 
 defaultConfig :: Config
@@ -71,6 +74,7 @@ defaultConfig =
          , edgeType = Just A.SplineEdges
          , configFile = Nothing
          , dotentity = False
+         , edgePattern = Just A.Dashed
          }
 
 defaultConfigFile :: B.ByteString
@@ -78,7 +82,8 @@ defaultConfigFile = B.unlines
   [[r|# Erd (~/.erd.yaml) default configuration file.|],
    B.append [r|output-format: pdf           # Supported formats: |] (defVals fmts),
    B.append [r|edge-style: spline           # Supported values : |] (defVals edges),
-   B.append [r|dot-entity: false            # Supported values : |] (defVals valBool)
+   B.append [r|dot-entity: false            # Supported values : |] (defVals valBool),
+   B.append [r|edge-pattern: dashed         # Supported values : |] (defVals edgePatterns)
   ]
   where
     defVals = B.pack . unwords . M.keys
@@ -161,8 +166,7 @@ opts =
                       Just gfmt -> return c {outfmt = Just gfmt}
                 )
                 "FMT")
-      (printf "Force the output format to one of:\n%s"
-              (intercalate ", " $ M.keys fmts))
+      (descriptionWithValuesList "Force the output format to one of" fmts)
   , O.Option "e" ["edge"]
       (O.ReqArg (\edge cIO -> do
                     c <- cIO
@@ -174,8 +178,18 @@ opts =
                       Just x -> return c {edgeType = Just x}
                 )
                 "EDGE")
-      (printf "Select one type of edge:\n%s"
-              (intercalate ", " $ M.keys edges))
+      (descriptionWithValuesList "Select one type of edge" edges)
+  , O.Option "p" ["edge-pattern"]
+      (O.ReqArg (\epat cIO -> do
+                    c <- cIO
+                    case toEdgePattern epat of
+                      Nothing -> do
+                        ef "'%s' is not a valid type of edge pattern." epat
+                        exitFailure
+                      Just x -> return c {edgePattern = Just x}
+                )
+                "PATTERN")
+      (descriptionWithValuesList "Select one of the edge patterns" edgePatterns)
   , O.Option "d" ["dot-entity"]
       (O.NoArg (\cIO -> do
                     c <- cIO
@@ -183,13 +197,17 @@ opts =
       ("When set, output will consist of regular dot tables instead of HTML tables.\n"
       ++ "Formatting will be disabled. Use only for further manual configuration.")
   , O.Option "v" ["version"]
-      (O.NoArg $ const erdVersion) "Shows version of application and revision code.."
+      (O.NoArg $ const erdVersion) "Shows version of application and revision code."
   ]
+  where
+    descriptionWithValuesList :: String -> M.Map String a -> String
+    descriptionWithValuesList txt m = printf (txt++":\n%s.") (intercalate ", " $ M.keys m)
 
 toConfig :: ConfigFile -> Config
-toConfig c = defaultConfig {outfmt    = toGraphFmt $ cFmtOut c,
-                            edgeType  = toEdgeG $ cEdgeType c,
-                            dotentity = cDotEntity c }
+toConfig c = defaultConfig {outfmt      = toGraphFmt $ cFmtOut c,
+                            edgeType    = toEdgeG $ cEdgeType c,
+                            dotentity   = cDotEntity c,
+                            edgePattern = toEdgePattern $ cEdgePattern c}
 
 -- | Reads and parses configuration file at default location: ~/.erd.yaml
 readGlobalConfigFile :: IO (Maybe ConfigFile)
@@ -240,6 +258,13 @@ valBool = M.fromList
   [ ("true", True)
   , ("false", False) ]
 
+edgePatterns :: M.Map String (Maybe A.StyleName)
+edgePatterns = M.fromList
+  [ ("solid", Just A.Solid)
+  , ("dashed", Just A.Dashed)
+  , ("dotted", Just A.Dotted)
+  ]
+
 -- | takeExtension returns the last extension from a file path, or the
 -- empty string if no extension was found. e.g., the extension of
 -- "wat.pdf" is "pdf".
@@ -252,6 +277,9 @@ toGraphFmt ext = M.findWithDefault Nothing ext fmts
 
 toEdgeG :: String -> Maybe A.EdgeType
 toEdgeG edge = M.findWithDefault Nothing edge edges
+
+toEdgePattern :: String -> Maybe A.StyleName
+toEdgePattern epat = M.findWithDefault Nothing epat edgePatterns
 
 usageExit :: IO a
 usageExit = usage >> exitFailure

--- a/src/Erd/Config.hs
+++ b/src/Erd/Config.hs
@@ -57,6 +57,10 @@ data ConfigFile = ConfigFile
     }
     deriving Show
 
+-- | A ConfigFile with all fields initialized with Nothing.
+emptyConfigFile :: ConfigFile
+emptyConfigFile = ConfigFile Nothing Nothing Nothing Nothing
+
 instance FromJSON ConfigFile where
   parseJSON (Y.Object v) =
     ConfigFile <$>
@@ -64,6 +68,7 @@ instance FromJSON ConfigFile where
     v .:? "edge-style" <*>
     v .:? "dot-entity" <*>
     v .:? "edge-pattern"
+  parseJSON Y.Null = return emptyConfigFile
   parseJSON _ = fail "Incorrect configuration file."
 
 defaultConfig :: Config

--- a/src/Erd/Config.hs
+++ b/src/Erd/Config.hs
@@ -206,7 +206,7 @@ opts =
   ]
   where
     descriptionWithValuesList :: String -> M.Map String a -> String
-    descriptionWithValuesList txt m = printf (txt++":\n%s.") (intercalate ", " $ M.keys m)
+    descriptionWithValuesList txt m = printf (txt <> ":\n%s.") (intercalate ", " $ M.keys m)
 
 toConfig :: ConfigFile -> Config
 toConfig c = defaultConfig {outfmt      = cFmtOut c >>= toGraphFmt,


### PR DESCRIPTION
Closes #93. (I've noticed this is a duplicate of #33.)

I included the new option in the same manner as the existing ones. This means the field is mandatory in the `.yaml` config file. However, this implies that the change is breaking for people who use the config file.

Perhaps it would be better to make the `edge-pattern` field optional in the `.yaml` config? If so, what about `dot-entity` (which is not in the latest 0.2.1.0-RC1 release) and other options? I believe they should be optional too, but I'd rather know your opinion before I make the change.