### PR TITLE
IE (crow's foot) notation for cardinalities of relations (#92, #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,16 +137,17 @@ The PDF should now contain a graph that looks like this:
 
 ### Available command-line options
 
-| Short      | Long                   | Description                                                                                                                                                                    |
-|------------|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| -c[FILE]   | --config[=FILE]        | Configuration file.                                                                                                                                                            |
-| -i FILE    | --input=FILE           | When set, input will be read from the given file. Otherwise, stdin will be used.                                                                                               |
-| -o FILE    | --output=FILE          | When set, output will be written to the given file. Otherwise, stdout will be used. If given and if --fmt is omitted, then the format will be guessed from the file extension. |
-| -f FMT     | --fmt=FMT              | Force the output format to one of: bmp, dot, eps, gif, jpg, pdf, plain, png, ps, ps2, svg, tiff.                                                                               |
-| -e EDGE    | --edge=EDGE            | Select one type of edge: compound, noedge, ortho, poly, spline.                                                                                                                |
-| -d         | --dot-entity           | When set, output will consist of regular dot tables instead of HTML tables. Formatting will be disabled.                                                                       |
-| -p PATTERN | --edge-pattern=PATTERN | Select one of the edge patterns: dashed, dotted, solid.                                                                                                                  |
-| -h         | --help                 | Show this usage message.                                                                                                                                                       |
+| Short       | Long                   | Description                                                                                                                                                                    |
+|-------------|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -c[FILE]    | --config[=FILE]        | Configuration file.                                                                                                                                                            |
+| -i FILE     | --input=FILE           | When set, input will be read from the given file. Otherwise, stdin will be used.                                                                                               |
+| -o FILE     | --output=FILE          | When set, output will be written to the given file. Otherwise, stdout will be used. If given and if --fmt is omitted, then the format will be guessed from the file extension. |
+| -f FMT      | --fmt=FMT              | Force the output format to one of: bmp, dot, eps, gif, jpg, pdf, plain, png, ps, ps2, svg, tiff.                                                                               |
+| -e EDGE     | --edge=EDGE            | Select one type of edge: compound, noedge, ortho, poly, spline.                                                                                                                |
+| -d          | --dot-entity           | When set, output will consist of regular dot tables instead of HTML tables. Formatting will be disabled.                                                                       |
+| -p PATTERN  | --edge-pattern=PATTERN | Select one of the edge patterns: dashed, dotted, solid.                                                                                                                        |
+| -n NOTATION | --notation=NOTATION    | Select a notation style for cardinalities of relations: ie, uml.                                                                                                               |
+| -h          | --help                 | Show this usage message.                                                                                                                                                       |
 
 ### Formatting defined in configuration file
 


### PR DESCRIPTION
This adds support for the Information Engineering notation for cardinalities of relations (also known as Martin's notation, crow's foot notation and under other names). See e.g. https://vertabelo.com/blog/crow-s-foot-notation/. Merging this will close #92 and close #33.

I used the code by @nickolay from https://github.com/BurntSushi/erd/issues/33#issuecomment-485968070.

Along the way I removed `Maybe` from the `fmts`, `edges`, `edgePatterns` and `notations` dictionaries in `src/Erd/Config.hs`. I believe it looks more tidy this way.

I had to expand the rendering part in `app/Main.hs`. I believe this code would better be moved to `src/` (perhaps `src/Erd/Render.hs`). However,  I felt that such refactoring is out of scope for this PR.

------

I've noticed that there is a `changelog.md` file in the repo. Should I include a description of the changes in some new "unreleased" section of the file? I'm asking because I've thought that such policy could make preparing the future release easier.