### PR TITLE
Add flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1622445595,
+        "narHash": "sha256-m+JRe6Wc5OZ/mKw2bB3+Tl0ZbtyxxxfnAWln8Q5qs+Y=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7d706970d94bc5559077eb1a6600afddcd25a7c8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1623167903,
+        "narHash": "sha256-m1JHo/kfsA+wcbZeYa0Ri96MSUZ3pR5PSLFfOq3+OME=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f2f583eceb7b6ab9a7f0c9b14dfaac9d0b059a10",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "Translates a plain text description of a relational database schema to a graphical entity-relationship diagram";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        haskellPackages = pkgs.haskellPackages;
+
+        jailbreakUnbreak = pkg:
+          pkgs.haskell.lib.doJailbreak (pkg.overrideAttrs (_: { meta = { }; }));
+
+        packageName = "erd";
+      in {
+        packages.${packageName} =
+          haskellPackages.callCabal2nix packageName self rec {
+            # Dependency overrides go here
+          };
+
+        defaultPackage = self.packages.${system}.${packageName};
+
+        devShell = pkgs.mkShell {
+          buildInputs = with haskellPackages; [
+            haskell-language-server
+            ghcid
+            cabal-install
+          ];
+          inputsFrom = builtins.attrValues self.packages.${system};
+        };
+      });
+}


### PR DESCRIPTION
With this PR, you can simply build erd using the following command:

```sh
nix build .
```

It will also allow you to run the program without explicitly installing it:

```sh
nix run BurntSushi/erd -- FLAGS...
```

I've just used a `flake.nix` template from Serokell: https://github.com/serokell/templates/tree/master/haskell-cabal2nix

This uses the [Nix flakes](https://nixos.wiki/wiki/Flakes) feature. It is unavailable on stable releases of Nix yet, but you can replace default.nix by following this procedure: https://nixos.wiki/wiki/Flakes#Using_flakes_project_from_a_legacy_Nix.