### PR TITLE
Releasing 0.2.2.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,17 @@
+0.2.2.0 (2022-11-??)
+
+* Bump stack lts version to 18.28
+
+* [Fix] Character encoding issue (PR #99, #102)
+
+* [Add]  IE (crow's foot) notation for cardinalities of relations. (PR #92, #33, #100)
+
+* [Add]  customizable edge pattern (PR #93, #95)
+
+* [Add] -v command-line flag to show version and git revision code. (PR #77)
+
+* [Add] Support of regular dot tables as output (PR #74)
+
 0.2.1.0 (2020-02-01)
 
 * Add -v command-line flag to show verions and git revision.

--- a/erd.cabal
+++ b/erd.cabal
@@ -2,7 +2,7 @@
 -- see http://haskell.org/cabal/users-guide/
 
 name:                erd
-version:             0.2.1.0
+version:             0.2.2.0
 homepage:            https://github.com/BurntSushi/erd
 license:             PublicDomain
 license-file:        UNLICENSE

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.0
+resolver: lts-18.28
 
 packages:
 - '.'


### PR DESCRIPTION
Releasing 0.2.2.0

- [ ] Update source onto hackage
- [ ] Find out if `static-haskell-nix` can be still used, otherwise: 
- [ ] Someone, creating a static binary to include it in the release object?