### PR TITLE
Fix ambiguous import of `elem`

### DIFF
--- a/src/Text/Parsec/Erd/Parser.hs
+++ b/src/Text/Parsec/Erd/Parser.hs
@@ -17,7 +17,7 @@ import           Control.Monad         (liftM2, void, when)
 import           Data.Char             (isAlphaNum, isControl, isSpace)
 import qualified Data.Map              as M
 import           Data.Maybe
-import           Data.Text.Lazy
+import           Data.Text.Lazy        hiding (elem)
 import           Text.Parsec
 import           Text.Parsec.Text.Lazy
 import           Text.Printf           (printf)


### PR DESCRIPTION
I've run into trouble trying to create a docker container for asciidoctor that runs on arm64.

As of right now `erd` can not be installed on Alpine Linux 3.17 arm64 using `cabal v2-update && cabal v2-install erd`. When building the following error occurs:

```
Configuring executable 'erd' for erd-0.2.1.0..
Preprocessing executable 'erd' for erd-0.2.1.0..
Building executable 'erd' for erd-0.2.1.0..
[1 of 7] Compiling Erd.ER           ( src/Erd/ER.hs, dist/build/erd/erd-tmp/Erd/ER.o, dist/build/erd/erd-tmp/Erd/ER.dyn_o )
[2 of 7] Compiling Erd.Render       ( src/Erd/Render.hs, dist/build/erd/erd-tmp/Erd/Render.o, dist/build/erd/erd-tmp/Erd/Render.dyn_o )
[3 of 7] Compiling Paths_erd        ( dist/build/erd/autogen/Paths_erd.hs, dist/build/erd/erd-tmp/Paths_erd.o, dist/build/erd/erd-tmp/Paths_erd.dyn_o )
[4 of 7] Compiling Erd.Config       ( src/Erd/Config.hs, dist/build/erd/erd-tmp/Erd/Config.o, dist/build/erd/erd-tmp/Erd/Config.dyn_o )
[5 of 7] Compiling Text.Parsec.Erd.Parser ( src/Text/Parsec/Erd/Parser.hs, dist/build/erd/erd-tmp/Text/Parsec/Erd/Parser.o, dist/build/erd/erd-tmp/Text/Parsec/Erd/Parser.dyn_o )

src/Text/Parsec/Erd/Parser.hs:64:27: error:
    Ambiguous occurrence ‘elem’
    It could refer to
       either ‘Prelude.elem’,
              imported from ‘Prelude’ at src/Text/Parsec/Erd/Parser.hs:3:8-29
              (and originally defined in ‘Data.Foldable’)
           or ‘Data.Text.Lazy.elem’,
              imported from ‘Data.Text.Lazy’ at src/Text/Parsec/Erd/Parser.hs:20:1-31
   |
64 |   let (ispk, isfk) = ('*' `elem` keys, '+' `elem` keys)
   |                           ^^^^^^

src/Text/Parsec/Erd/Parser.hs:64:44: error:
    Ambiguous occurrence ‘elem’
    It could refer to
       either ‘Prelude.elem’,
              imported from ‘Prelude’ at src/Text/Parsec/Erd/Parser.hs:3:8-29
              (and originally defined in ‘Data.Foldable’)
           or ‘Data.Text.Lazy.elem’,
              imported from ‘Data.Text.Lazy’ at src/Text/Parsec/Erd/Parser.hs:20:1-31
   |
64 |   let (ispk, isfk) = ('*' `elem` keys, '+' `elem` keys)
   |                                            ^^^^^^
Error: cabal: Failed to build exe:erd from erd-0.2.1.0. See the build log
above for details.
```

I suppose this is due to Alpine using GHC `9.0.2`. 

This PR fixes this issue, which would arise later when bumping the stack-resolver version to `19.5` or beyond.