### PR TITLE
Build arm64 Docker image

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -34,19 +34,28 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push by digest
+      - name: Build and export the image to Docker
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:test
+      - name: Test the image
+        run: |
+          docker run --rm ${{ env.IMAGE_NAME }}:test < examples/nfldb.er >| out.pdf
+      - name: Push the image by digest
         id: build
         uses: docker/build-push-action@v5
         with:
           context: .
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-      - name: Export digest
+      - name: Export the digest
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
-      - name: Upload digest
+      - name: Upload the digest
         uses: actions/upload-artifact@v3
         with:
           name: digests

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -26,6 +26,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern=v{{version}}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to the Container Registry
@@ -42,12 +44,14 @@ jobs:
           tags: ${{ env.IMAGE_NAME }}:test
       - name: Test the image
         run: |
-          docker run --rm ${{ env.IMAGE_NAME }}:test < examples/nfldb.er >| out.pdf
+          docker run --rm ${{ env.IMAGE_NAME }}:test < examples/nfldb.er >| nfldb.png
       - name: Push the image by digest
         id: build
         uses: docker/build-push-action@v5
         with:
           context: .
+          tags: |
+            ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
       - name: Export the digest
@@ -62,6 +66,11 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: example-diagram-nfldb
+          path: nfldb.png
 
   merge-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -42,7 +42,7 @@ jobs:
           tags: ${{ env.IMAGE_NAME }}:test
       - name: Test the image
         run: |
-          docker run --rm ${{ env.IMAGE_NAME }}:test < examples/nfldb.er >| nfldb.png
+          docker run --rm -i ${{ env.IMAGE_NAME }}:test < examples/nfldb.er >| nfldb.pdf
       - name: Push the image by digest
         id: build
         uses: docker/build-push-action@v5
@@ -66,7 +66,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: example-diagram-nfldb
-          path: nfldb.png
+          path: nfldb.pdf
 
   merge-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -26,8 +26,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern=v{{version}}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to the Container Registry
@@ -50,8 +48,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          tags: |
-            ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
       - name: Export the digest

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,4 +1,4 @@
-name: Create and publish a Docker image
+name: Create and publish a multi-architecture Docker image
 
 on:
   push:
@@ -6,39 +6,82 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
 
 jobs:
-  build-and-push-image:
-    runs-on: ubuntu-latest
+  build-image:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, buildjet-4vcpu-ubuntu-2204-arm]
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2.1.0
+        uses: actions/checkout@v4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to the Container Registry
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4.1.1
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern=v{{version}}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v3.2.0
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
-          tags: |
-            ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-image:
+    runs-on: ubuntu-latest
+    needs:
+      - build-image
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+      - name: Login to the Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #  - Go to Preferences > Resources > Memory
 #  - and give docker more memory (eg: 4gb)
 
-FROM haskell:8
+FROM haskell:8-slim
 
 WORKDIR /opt/erd
 


### PR DESCRIPTION
Builds and tests a multi-architecture Docker image for both `linux/amd64` and `linux/arm64` platforms as discussed in this [comment](https://github.com/BurntSushi/erd/pull/108#issuecomment-1565457755) and in #114. This allows ARM-based machines to run the image natively with no emulation.

![manifest-digest](https://github.com/BurntSushi/erd/assets/10233016/165b320d-9500-4b66-b7fa-dab7ee6536a1)

This includes the following changes:

- Builds the `linux/amd64` and `linux/arm64` images on dedicated native runners. The typical "low-effort" QEMU-based approach to building multi-arch images is not possible in this case due to memory constraints with the free GitHub runners, so the changes in this PR rely on a 3rd-party integration with [BuildJet](https://buildjet.com/for-github-actions) to provide the native `arm64` runner. BuildJet provides $5 of free runner time to get started, which equates to $5 / $0.008 = 625 minutes total with the runner I chose (see [pricing info](https://buildjet.com/for-github-actions/docs/about/pricing)). Each build takes about 15 minutes, so I don't anticipate this project needing to spend any money whatsoever on this for the forseeable future. They also didn't collect credit card information from me when I signed up, so there's no danger of being accidentally charged.
- Tests the image using the `examples/nfldb.er` diagram and stores the resulting PNG as an artifact for review.
- Switches the base image to `haskell:8-slim`, which is about half the size of `haskell:8` (341MB vs 635MB).

I appreciate that this reliance on a 3rd party is far from optimal and fully understand if the decision is made to reject this PR. The only two other viable approaches to build multi-archecture binaries would be to:

- Set up a self-hosted `arm64` runner.
- Set up a GHC cross-compiler and run everything on the free GitHub `amd64` runners. This is apparently quite complex to do with Haskell and beyond the effort I'm willing to contribute.

Closes #40
Closes #114